### PR TITLE
Zprovozneni filtrovani pri nevalidnim inline formulari

### DIFF
--- a/Nextras/Datagrid/Datagrid.php
+++ b/Nextras/Datagrid/Datagrid.php
@@ -379,7 +379,7 @@ class Datagrid extends UI\Control
 			}
 		}
 
-		$form->onSuccess[] = $this->processForm;
+		$form->onSubmit[] = $this->processForm;
 		return $form;
 	}
 
@@ -388,7 +388,7 @@ class Datagrid extends UI\Control
 	public function processForm(UI\Form $form)
 	{
 		if (isset($form['edit'])) {
-			if ($form['edit']['save']->isSubmittedBy()) {
+			if ($form['edit']['save']->isSubmittedBy() && $form->isValid()) {
 				Nette\Callback::create($this->editFormCallback)->invokeArgs(array(
 					$form['edit']
 				));


### PR DESCRIPTION
Pokud jsou na inline editacnim formulari nastavena validacni pravidla napr. Form:FILLED, tak nelze filtrovat. Formular se nedostane pres nevalidni cast formulare k onSuccess, a to ani pokud zrovna editaci neprovadim. Editacni formular nema zadna data, tak pada na tom FILLED.
