### PR TITLE
support for row number

### DIFF
--- a/Nextras/Datagrid/Datagrid.latte
+++ b/Nextras/Datagrid/Datagrid.latte
@@ -76,6 +76,7 @@
 {foreach $data as $row}
 	{var $primary = $control->getter($row, $rowPrimaryKey)}
 	{var $editRow = $editRowKey == $primary}
+	{var $rowNumber = $iterator->getCounter()}
 	<tr n:snippet="rows-$primary" data-grid-primary="{$primary}">
 		{foreach $columns as $column}
 			{var $cell = $control->getter($row, $column->name, FALSE)}
@@ -90,7 +91,7 @@
 				</td>
 			{else}
 				{ifset #col-$column->name}
-					{include #"col-{$column->name}" row => $row, cell => $cell}
+					{include #"col-{$column->name}" row => $row, rowNumber => $rowNumber, cell => $cell}
 				{else}
 					<td class="col-{$column->name}">{$cell}</td>
 				{/ifset}


### PR DESCRIPTION
It will be possible to replace primary key cell (eg. id column) with the current row number.

Example:

``` html
{define col-id}
<td>
{$paginator->getItemsPerPage() * $paginator->getPage() - $paginator->getItemsPerPage() + $rowNumber}.
</td>
{/define}
```
