### PR TITLE
In creation of edit form check for 'edit' part of POST data

### DIFF
--- a/Nextras/Datagrid/Datagrid.php
+++ b/Nextras/Datagrid/Datagrid.php
@@ -367,7 +367,7 @@ class Datagrid extends UI\Control
 	{
 		$form = new UI\Form;
 
-		if ($this->editFormFactory && ($this->editRowKey || !empty($_POST))) {
+		if ($this->editFormFactory && ($this->editRowKey || !empty($_POST['edit']))) {
 			$data = $this->editRowKey && empty($_POST) ? $this->getData($this->editRowKey) : NULL;
 			$form['edit'] = Nette\Callback::create($this->editFormFactory)->invokeArgs(array($data));
 


### PR DESCRIPTION
This prevents creation of edit form in case POST data were filled from different sources (like filter).

Create a grid. Use filter (without this commit this triggers creation of edit form thus creating hidden input with edit[$primaryKey]) and now click edit (this downloads only requested row from the server including https://github.com/nextras/datagrid/blob/master/Nextras/Datagrid/Datagrid.latte#L103). You won't be able to save the edit because edit[$primaryKey] value will be overwritten by the edit[$primaryKey] created before.
