### PR TITLE
Allow returning objects and boolean value false for filters

### DIFF
--- a/Nextras/Datagrid/Datagrid.php
+++ b/Nextras/Datagrid/Datagrid.php
@@ -461,7 +461,13 @@ class Datagrid extends UI\Control
 				$values = $form['filter']->getValues(TRUE);
 				unset($values['filter']);
 				$values = array_filter($values, function($val) {
-					return is_array($val) ? (count($val) > 0) : (strlen($val) > 0);
+					if (is_array($val)) {
+						return !empty($val);
+					}
+					if (is_string($val)) {
+						return strlen($val) > 0;
+					}
+					return $val !== null;
 				});
 				if ($this->paginator) {
 					$this->page = $this->paginator->page = 1;


### PR DESCRIPTION
Only empty arrays, null and empty strings are excluded from filters. `strlen(false)` returns 0

see http://forum.nette.org/cs/7418-addon-dateinput-dateinput-html-5-kompatibilni-formularove-prvky-pro-vyber-data?p=2#p119135
