### PR TITLE
Fixed compatibility with Nette 2.2.2

### DIFF
--- a/src/Datagrid.latte
+++ b/src/Datagrid.latte
@@ -163,9 +163,10 @@
 {/foreach}
 
 {form form class => 'ajax'}
+{var $_internal = isset($_b) ? $_b : $_l}
 {var $template->hasActionsColumn =
-	isset($_l->blocks['row-actions']) ||
-	isset($_l->blocks['global-actions']) ||
+	isset($_internal->blocks['row-actions']) ||
+	isset($_internal->blocks['global-actions']) ||
 	isset($_form['filter']) ||
 	(bool) $control->getEditFormFactory()
 }


### PR DESCRIPTION
Similar fix as in nextras/latte-macros@f8d4c32a3ebfd8c59623abb44b29500ac9d067ec.
