### PR TITLE
Fix issue when JS is fired without element

### DIFF
--- a/js/nextras.datagrid.js
+++ b/js/nextras.datagrid.js
@@ -39,10 +39,12 @@ $.nette.ext('datagrid', {
 		});
 	},
 	before: function(xhr, settings) {
-		this.grid = settings.nette.el.parents('.grid');
+		if( settings.nette && settings.nette.el )
+			this.grid = settings.nette.el.parents('.grid');
 	},
 	success: function() {
-		this.load(this.grid);
+		if(this.grid)
+			this.load(this.grid);
 	}
 }, {
 	activeGrid: null,

--- a/js/nextras.datagrid.js
+++ b/js/nextras.datagrid.js
@@ -39,7 +39,9 @@ $.nette.ext('datagrid', {
 		});
 	},
 	before: function(xhr, settings) {
-		this.grid = settings.nette.el.parents('.grid');
+        try{
+            this.grid = settings.nette.el.parents('.grid');
+        }catch(_){ this.grid = $([]); }		
 	},
 	success: function() {
 		this.load(this.grid);

--- a/js/nextras.datagrid.js
+++ b/js/nextras.datagrid.js
@@ -39,12 +39,10 @@ $.nette.ext('datagrid', {
 		});
 	},
 	before: function(xhr, settings) {
-		if( settings.nette && settings.nette.el )
-			this.grid = settings.nette.el.parents('.grid');
+		this.grid = settings.nette.el.parents('.grid');
 	},
 	success: function() {
-		if(this.grid)
-			this.load(this.grid);
+		this.load(this.grid);
 	}
 }, {
 	activeGrid: null,


### PR DESCRIPTION
If someone call $.nette.ajax( url ), datagrid will throw exception and abort request, this patch will prevent that...