### PR TITLE
Fixed issue #41

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -18,7 +18,9 @@ use Nette\Utils\Callback;
 use Nette\Localization\ITranslator;
 
 
-
+/**
+ * @metod onAttached
+ */
 class Datagrid extends UI\Control
 {
 	/** @var string */
@@ -84,7 +86,10 @@ class Datagrid extends UI\Control
 	/** @var array */
 	protected $cellsTemplates = array();
 
-
+	/**
+	 * 
+	 */
+	public $onAttached = array();
 
 	/**
 	 * Adds column
@@ -319,6 +324,7 @@ class Datagrid extends UI\Control
 	protected function attached($presenter)
 	{
 		parent::attached($presenter);
+		$thid->onAttached($this);
 		$this->filterDataSource = $this->filter;
 	}
 

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -324,7 +324,7 @@ class Datagrid extends UI\Control
 	protected function attached($presenter)
 	{
 		parent::attached($presenter);
-		$thid->onAttached($this);
+		$this->onAttached($this);
 		$this->filterDataSource = $this->filter;
 	}
 


### PR DESCRIPTION
Thanks to onAttached event, you can now put your custom variables to datagrid template and register macros to datagrid template without need to connect datagrid to component tree in constructor, which breaked pagination.

Adding your own macros and other variables looks like this:

        $grid = new Datagrid();
        $grid->onAttached[] = function(Datagrid $datagrid) {
            $datagrid->template->addFilter('myCoolMacro', function ($s) {
                return myCoolMacro($s);
            });
            $datagrid->template->myVariable = $this->myVariable;
        };