### PR TITLE
Domain nextras.cz doesn't exist.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,5 +13,5 @@ $ composer require nextras/datagrid
 
 ### Docs & sources
 
-- [Documentation](http://nextras.cz/datagrid/docs)
+- [Documentation](http://nextras.org/datagrid/docs)
 - [Demo](http://nextras.org/datagrid)


### PR DESCRIPTION
There is wrong web address to nextras datagrid documentation. 