### PR TITLE
DataGrid: after edit redraw all rows

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -489,9 +489,7 @@ class Datagrid extends UI\Control
 				}
 			}
 			if ($form['edit']['cancel']->isSubmittedBy() || ($form['edit']['save']->isSubmittedBy() && $form['edit']->isValid())) {
-				$editRowKey = $form['edit'][$this->rowPrimaryKey]->getValue();
-				$this->redrawRow($editRowKey);
-				$this->getData($editRowKey);
+				$this->redrawControl('rows');
 			}
 			if ($this->editRowKey !== null) {
 				$this->redrawRow($this->editRowKey);


### PR DESCRIPTION
After editing the row could not be in result when not ordered by ID w.
If there are data in grid sorted by name and i change the name using inline edit this row can be now on different page and grid needs to redraw all rows.