### PR TITLE
DataSource callback recive only valid filter values

### DIFF
--- a/src/Datagrid.latte
+++ b/src/Datagrid.latte
@@ -21,7 +21,8 @@
 {php
 	$hasActionsColumn =
 		(bool) $control->getEditFormFactory() /* we may render only one row so the form[filter] may not be created */
-		|| isset($this->blockQueue["row-actions"]);
+		|| isset($this->blockQueue["row-actions"])
+		|| isset($form['filter']);
 	$hasGlobalActionsColumn = isset($form['actions']);
 
 	foreach ($_templates as $_template):

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -337,11 +337,22 @@ class Datagrid extends UI\Control
 	protected function getData($key = null)
 	{
 		if (!$this->data) {
+			$validFilterData = [];
+			if ($this->filterFormFactory) {
+				$this['form']->isValid(); // triggers validation
+				foreach ($this['form']['filter']->controls as $name => $control) {
+					if ($control->getErrors() === []) {
+						$validFilterData[$name] = $control->getValue();
+					}
+				}
+				$validFilterData = $this->filterFormFilter($validFilterData);
+			}
+
 			$onlyRow = $key !== null && $this->presenter->isAjax();
 			if (!$onlyRow && $this->paginator) {
 				$itemsCount = call_user_func(
 					$this->paginatorItemsCountCallback,
-					$this->filterDataSource,
+					$validFilterData,
 					$this->orderColumn ? [$this->orderColumn, strtoupper($this->orderType)] : null
 				);
 
@@ -353,7 +364,7 @@ class Datagrid extends UI\Control
 
 			$this->data = call_user_func(
 				$this->dataSourceCallback,
-				$this->filterDataSource,
+				$validFilterData,
 				$this->orderColumn ? [$this->orderColumn, strtoupper($this->orderType)] : null,
 				$onlyRow ? null : $this->paginator
 			);


### PR DESCRIPTION
This is rather a hotfix than proper solution. I don't use the DataGrid with AJAX, so I don't fully understand the `$filter`, `$filterDefaults` and `$filterDataSource` members combinations.