### PR TITLE
Fix for loading defined latte blocks.

### DIFF
--- a/src/Datagrid.latte
+++ b/src/Datagrid.latte
@@ -10,7 +10,7 @@
 {var $_templates = []}
 {foreach $cellsTemplates as $cellsTemplate}
 	{php
-		$_template = $this->createTemplate($cellsTemplate, $this->params, "import");
+		$_template = $this->createTemplate($cellsTemplate, $this->params, "includeblock");
 		$_template->render();
 		$_templates[] = $_template;
 	}


### PR DESCRIPTION
Řeší problém s chybou načítaní dynamicky generovaných bloků v latte při použití nette 2.4+.
Jedná se konkrétně o: Call to undefined method Nette\Forms\Container::getControl(), did you mean getControls()?

Zmiňované zde:
https://forum.nette.org/cs/13165-nextras-datagrid-datagrid-se-vsim-jak-ma-byt?p=10
Viz.: https://doc.nette.org/cs/2.4/migration-2-4

