### PR TITLE
Disables sorting by unregistered column

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -338,6 +338,11 @@ class Datagrid extends UI\Control
 	{
 		if (!$this->data) {
 			$onlyRow = $key !== null && $this->presenter->isAjax();
+			
+			if ( $this->orderColumn !== NULL && !isset( $this->columns[ $this->orderColumn ] ) ) {
+				$this->orderColumn = NULL;
+			}
+			
 			if (!$onlyRow && $this->paginator) {
 				$itemsCount = call_user_func(
 					$this->paginatorItemsCountCallback,
@@ -349,10 +354,6 @@ class Datagrid extends UI\Control
 				if ($this->paginator->page !== $this->page) {
 					$this->paginator->page = $this->page = 1;
 				}
-			}
-
-			if ( $this->orderColumn !== NULL && !isset( $this->columns[ $this->orderColumn ] ) ) {
-				$this->orderColumn = NULL;
 			}
 			
 			$this->data = call_user_func(

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -339,7 +339,7 @@ class Datagrid extends UI\Control
 		if (!$this->data) {
 			$onlyRow = $key !== null && $this->presenter->isAjax();
 			
-			if ( $this->orderColumn !== NULL && !isset( $this->columns[ $this->orderColumn ] ) ) {
+			if ($this->orderColumn !== NULL && !isset($this->columns[$this->orderColumn])) {
 				$this->orderColumn = NULL;
 			}
 			

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -355,7 +355,7 @@ class Datagrid extends UI\Control
 					$this->paginator->page = $this->page = 1;
 				}
 			}
-			
+
 			$this->data = call_user_func(
 				$this->dataSourceCallback,
 				$this->filterDataSource,

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -351,6 +351,10 @@ class Datagrid extends UI\Control
 				}
 			}
 
+			if ( $this->orderColumn !== NULL && !isset( $this->columns[ $this->orderColumn ] ) ) {
+				$this->orderColumn = NULL;
+			}
+			
 			$this->data = call_user_func(
 				$this->dataSourceCallback,
 				$this->filterDataSource,


### PR DESCRIPTION
Sorting by unregistered columns does not make a sense. Disabling this feature can prepend many errors and is safer.