### PR TITLE
Order can now have multiple columns

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -20,8 +20,11 @@ class Column extends Nette\Object
 	/** @var string */
 	public $label;
 
-	/** @var string */
+	/** @var bool */
 	protected $sort = FALSE;
+
+	/** @var bool */
+	protected $required = FALSE;
 
 	/** @var Datagrid */
 	protected $grid;
@@ -35,16 +38,16 @@ class Column extends Nette\Object
 	}
 
 
-	public function enableSort($default = NULL)
+	public function enableSort($default = NULL, $required = FALSE)
 	{
 		$this->sort = TRUE;
+		$this->required = ($required && $default && $default !== Datagrid::ORDER_NONE);
 		if ($default !== NULL) {
-			if ($default !== Datagrid::ORDER_ASC && $default !== Datagrid::ORDER_DESC) {
+			if ($default !== Datagrid::ORDER_ASC && $default !== Datagrid::ORDER_DESC && $default !== Datagrid::ORDER_NONE) {
 				throw new \InvalidArgumentException('Unknown order type.');
 			}
 
-			$this->grid->orderColumn = $this->name;
-			$this->grid->orderType = $default;
+			$this->grid->order[$this->name] = $default;
 		}
 		return $this;
 	}
@@ -58,24 +61,27 @@ class Column extends Nette\Object
 
 	public function getNewState()
 	{
-		if ($this->isAsc()) {
-			return Datagrid::ORDER_DESC;
+		$state = $this->grid->order;
+		if($this->isAsc()) {
+			$state[$this->name] = Datagrid::ORDER_DESC;
 		} elseif ($this->isDesc()) {
-			return '';
+			$state[$this->name] = ($this->force ? Datagrid::ORDER_ASC : Datagrid::ORDER_NONE);
 		} else {
-			return Datagrid::ORDER_ASC;
+			$state[$this->name] = Datagrid::ORDER_ASC;
 		}
+
+		return $state;
 	}
 
 
 	public function isAsc()
 	{
-		return $this->grid->orderColumn === $this->name && $this->grid->orderType === Datagrid::ORDER_ASC;
+		return isset($this->grid->order[$this->name]) && $this->grid->order[$this->name] === Datagrid::ORDER_ASC;
 	}
 
 
 	public function isDesc()
 	{
-		return $this->grid->orderColumn === $this->name && $this->grid->orderType === Datagrid::ORDER_DESC;
+		return isset($this->grid->order[$this->name]) && $this->grid->order[$this->name] === Datagrid::ORDER_DESC;
 	}
 }

--- a/src/Datagrid.blocks.latte
+++ b/src/Datagrid.blocks.latte
@@ -28,7 +28,7 @@
 		{foreach $columns as $column}
 			<th class="grid-col-{$column->name}">
 				{if $column->canSort()}
-					<a href="{link sort! orderColumn => $column->name, orderType => $column->getNewState()}" class="ajax">{$column->label}</a>
+					<a href="{link sort! order => $column->getNewState()}" class="ajax">{$column->label}</a>
 					{if $column->isAsc()}
 						<span class="grid-sort-symbol grid-sort-symbol-asc"><em>&#9650;</em></span>
 					{elseif $column->isDesc()}
@@ -62,7 +62,7 @@
 	<tr class="grid-filters">
 		{ifset $form[actions]}
 			<th class="grid-col-global-actions"></th>
-		{/ifset}	
+		{/ifset}
 		{formContainer filter}
 		{foreach $columns as $column}
 			<th class="grid-col-{$column->name}">

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -27,6 +27,9 @@ class Datagrid extends UI\Control
 	/** @var string */
 	const ORDER_DESC = 'desc';
 
+	/** @var string */
+	const ORDER_NONE = 'none';
+
 	/** @var array of callbacks: function(Datagrid) */
 	public $onRender = [];
 
@@ -34,10 +37,7 @@ class Datagrid extends UI\Control
 	public $filter = [];
 
 	/** @persistent */
-	public $orderColumn;
-
-	/** @persistent */
-	public $orderType = self::ORDER_ASC;
+	public $order = [];
 
 	/** @persistent */
 	public $page = 1;
@@ -338,16 +338,12 @@ class Datagrid extends UI\Control
 	{
 		if (!$this->data) {
 			$onlyRow = $key !== null && $this->presenter->isAjax();
-			
-			if ($this->orderColumn !== NULL && !isset($this->columns[$this->orderColumn])) {
-				$this->orderColumn = NULL;
-			}
-			
+
 			if (!$onlyRow && $this->paginator) {
 				$itemsCount = call_user_func(
 					$this->paginatorItemsCountCallback,
 					$this->filterDataSource,
-					$this->orderColumn ? [$this->orderColumn, strtoupper($this->orderType)] : null
+					$this->getOrder()
 				);
 
 				$this->paginator->setItemCount($itemsCount);
@@ -359,7 +355,7 @@ class Datagrid extends UI\Control
 			$this->data = call_user_func(
 				$this->dataSourceCallback,
 				$this->filterDataSource,
-				$this->orderColumn ? [$this->orderColumn, strtoupper($this->orderType)] : null,
+				$this->getOrder(),
 				$onlyRow ? null : $this->paginator
 			);
 		}
@@ -595,6 +591,23 @@ class Datagrid extends UI\Control
 			}
 		}
 		return $filtered;
+	}
+
+
+	private function getOrder()
+	{
+		$order = [];
+		foreach($this->order as $column => $type){
+			if(!$column)
+				continue;
+			if($type !== self::ORDER_ASC && $type !== self::ORDER_DESC && $type) {
+				if($type !== self::ORDER_NONE)
+					unset($this->order[$column]);
+				continue;
+			}
+			$order[$column] = strtoupper($type);
+		}
+		return $order ?: null;
 	}
 
 


### PR DESCRIPTION
Order can now have multiple columns, but there is some BC changes.

Order of columns are based of call order of getNewState, so if you
manually change order of getNewState, or add custom $order, it can be
changed again by user (or if user change URL manually). This can be
fixed by calling columns in proper order on getOrder (not sure if this
is necessary as it may be intend for programmers to change order).

$order passed to data callback and data count callback is in key =>
value form, so it is easier to build order string.
$order = [
`column` => `ASC|DESC`
]

on $column->setOrder() is new parameter $required, this is if you require to have order set on that column, it will drop NULL option and change ASC -> DESC -> ASC -> DESC