### PR TITLE
Filter - FALSE is an empty value too

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -603,6 +603,6 @@ class Datagrid extends UI\Control
 
 	private static function isEmptyValue($value)
 	{
-		return $value === NULL || $value === '' || $value === [];
+		return $value === NULL || $value === '' || $value === [] || $value === false;
 	}
 }


### PR DESCRIPTION
When using checkboxes in our filters we noticed that even when defaulting to false the filter field is not considered empty.