### PR TITLE
Method redrawControl is now compatible with their parent.

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -307,9 +307,9 @@ class Datagrid extends UI\Control
 	}
 
 
-	public function redrawControl($snippet = null)
+	public function redrawControl($snippet = null, $redraw = true)
 	{
-		parent::redrawControl($snippet);
+		parent::redrawControl($snippet, $redraw);
 		if ($snippet === null || $snippet === 'rows') {
 			$this->sendOnlyRowParentSnippet = true;
 		}


### PR DESCRIPTION
![obrazek](https://user-images.githubusercontent.com/3403705/35334880-1a82ba36-0114-11e8-9581-1decf6e5644e.png)

Updated declaration of **redrawControl** in **Datagrid** class. Now this method is compatible with their parent declaration.